### PR TITLE
Fix failsafe when no controller is connected

### DIFF
--- a/bbrx/event_manager.cpp
+++ b/bbrx/event_manager.cpp
@@ -366,7 +366,7 @@ void event_manager_update() {
             #if defined(ENABLE_FAILSAFES) and defined(FAILSAFE_NO_CONTROLLER)
                 if (bind.action == BB_ACTION_SERVO) {
                     // write midpoint value to each servo motor (ie: turn it off)
-                    servos[bind.pin].writeMicroseconds(bind.servo_pwm_min);
+                    servos[bind.pin].writeMicroseconds(bind.servo_pwm_mid);
                 }
             #endif
 


### PR DESCRIPTION
Previous behaviour was to lock all motors to the minimum PWM period when all controllers had disconnected.  this was bad!  since it would lock motors into some "on" state.

New behaviour sets motors to the _medium_ PWM period (which should correspond to "off")